### PR TITLE
invalid MAC during wifi registertion

### DIFF
--- a/controllers/telegram_handlers.py
+++ b/controllers/telegram_handlers.py
@@ -493,12 +493,12 @@ async def register_wifi_handler(
         )
         return ConversationHandler.END
 
-    if len(user_response_args) != 3:
+    if len(user_response_args) != 2:
         await context.bot.send_message(
             chat_id=update.effective_chat.id,
             text="Invalid format. Please enter your response in the format: {rating} {query rating} {comment} or type cancel to cancel the operation.\nType cancel to cancel the operation.",
         )
-        return GET_FACULTY_FEEDBACK
+        return REGISTER_WIFI
 
     try:
         address = user_response_args[0]


### PR DESCRIPTION
hacktoberfest issue resolved #74

The _register wifi handler_ was comparing the length of _user response args_ with 3 while it should compare with 2, since the user has two provide only 2 arguments {MAC} {TRUE/FALSE}.